### PR TITLE
Address issue with note fingering parsing

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2956,7 +2956,6 @@ function xmlToDynamics(node) {
 }
 function xmlToFingering(node) {
     var ret = {};
-    var foundFinger = false;
     var foundSubstitution = false;
     var foundFontWeight = false;
     var foundFontStyle = false;
@@ -3026,7 +3025,7 @@ function xmlToFingering(node) {
     var ch3 = node;
     var dataFinger = getNumber(ch3, false);
     ret.finger = dataFinger;
-    if (!foundFinger) {
+    if (isNaN(ret.finger)) {
         ret.finger = -1;
     }
     if (!foundSubstitution) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3885,7 +3885,6 @@ export interface Fingering extends PrintStyle, Placement {
 
 function xmlToFingering(node: Node) {
     let ret: Fingering = <any> {};
-    let foundFinger = false;
     let foundSubstitution = false;
     let foundFontWeight = false;
     let foundFontStyle = false;
@@ -3955,7 +3954,7 @@ function xmlToFingering(node: Node) {
     let ch3 = node;
     let dataFinger = getNumber(ch3, false);
     ret.finger = dataFinger;
-    if (!foundFinger) {
+    if (isNaN(ret.finger)) {
         ret.finger = -1;
     }
     if (!foundSubstitution) {


### PR DESCRIPTION
What is this change?
This change updates the xml note fingering parser so that all fingerings are not read as '-1'.

What does it fix?
This change addresses an issue where fingerings are not being extracted properly from parsed files.

Is this a bug fix or a feature? Does it break any existing functionality or force me to update to a new version?
This is bug fix and should not break any existing functionality or require new dependency versions.

A musicxml file with fingerings is attached. Before this change, fingerings are always parsed as '-1'. After this change, fingerings are parsed correctly.

[Ab_major_scale.musicxml.zip](https://github.com/jnetterf/musicxml-interfaces/files/3989551/Ab_major_scale.musicxml.zip)
